### PR TITLE
passord regex fixed, debug info limited

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,21 +28,21 @@ if (!$mbox) {
 	// Filtrage des données
 
 	foreach ($_REQUEST as $key => $val) {
-		$val = preg_replace("/[^_A-Za-z0-9-\.&=]/i",'', $val);
+		$val = preg_replace("/[\'\"\\\?\~]/i",'', $val);
 		$_REQUEST[$key] = $val;
 	}
 
 	$newpass = '';
 	$newpass2 = '';
 	if (isset($_POST['newpass'])) {
-		$newpass = preg_replace("/[^_A-Za-z0-9-\.]/i",'', $_POST["newpass"]);
+		$newpass = preg_replace("/[[\'\"\\\?\~]/i",'', $_POST["newpass"]);
 	}
 	if (isset($_POST['newpass2'])) {
-		$newpass2 = preg_replace("/[^_A-Za-z0-9-\.]/i",'', $_POST["newpass2"]);
+		$newpass2 = preg_replace("/[[\'\"\\\?\~]/i",'', $_POST["newpass2"]);
 	}
 
 	$success = '';
-	if (strlen($newpass) >= 8 && $newpass == $newpass2) {
+	if (strlen($newpass) >= 8 && $newpass == $newpass2 && $_POST["newpass"]==$newpass) {
 	// Vérification du bon nouveau mot de passe (avec les deux champs puis on valide si ok )
 		$soap = new SoapClient('https://www.ovh.com/soapi/soapi-1.2.wsdl');
 
@@ -51,27 +51,27 @@ if (!$mbox) {
 			$language = null;
 			$multisession = false;
 			$session = $soap->login($nic,$pass,$language,$multisession);
-			$success .= "login successfull<br/>";
+			//$success .= "login successfull<br/>";
 		} catch(SoapFault $fault) {
-			$errors[] = "Error : ".$fault;
+			$errors[] = "Error : login";//.$fault;
 		}
 		//popModifyPassword
 		try {
 			$result = $soap->popModifyPassword($session, $domain, $email_name, $newpass, false);
-			$success .= "popModifyPassword successfull<br/>";
-			$success .= print_r($result);
-			$success .= "<br/>";
-			$success .= "<h3>Merci.<br />Mot de passe modifi&eacute;.</h3>";
-			$success .= "<h3>Il sera pris en compte d'ici une quinzaine de minutes</h3>";
+			//$success .= "popModifyPassword successfull<br/>";
+			//$success .= print_r($result);
+			//$success .= "<br/>";
+			$success .= "<h3>Thank you.<br />Password has been modified.</h3>";
+			$success .= "<h3>The change will be visible maximally in 15 minutes.</h3>";
 		} catch(SoapFault $fault) {
-			$errors[] = "Error : ".$fault;
+			$errors[] = "Error : popModifyPassword";//.$fault;.$fault;
 		}
 		//logout
 		try {
 			$result = $soap->logout($session);
-			$success .= "logout successfull<br/>";
+			//$success .= "logout successfull<br/>";
 		} catch(SoapFault $fault) {
-			$errors[] = "Error : ".$fault;
+			$errors[] = "Error : logout";//.$fault;.$fault;
 		}
 	} elseif (strlen($newpass) > 0 && $newpass != $newpass2) {
 	// ici le cas ou le premier nouveau mot de passe ne correspond pas au second
@@ -79,6 +79,9 @@ if (!$mbox) {
 	} elseif (strlen($newpass) > 0 && strlen($newpass) < 8) {
 	// Si le mot de passe fait moins de 8 caractères on refuse 
 		$errors[] = "Make sure your password has minimum 8 characters.";
+	} elseif ($_POST["newpass"]!=$newpass) {
+	// Si le mot de passe fait moins de 8 caractères on refuse 
+		$errors[] = "Password contains one or more of invalid characters:<ul><li>\'</li><li>\"</li><li>\\</li><li>\?</li><li>\~</li></ul>";
 	}
 }
 


### PR DESCRIPTION
Previous password validation regex restricted allowed characters and removed some of them without notification which lead to problems, also it wasn't necessary. Current version supports most of password characters and tells user when special ones was used and rejects such password.

Very verbose debug info was limited because positive debug is useless on production and negative debug with OVH API password variable expanded to cleartext is inadmissible behaviour.

Also one translation was made for language consistency.
